### PR TITLE
Add support for tokio's `AsyncRead` and `AsyncWrite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ futures-core = { version = "0.3.1", optional = true }
 futures-sink = { version = "0.3.1", optional = true }
 futures-01 = { version = "0.1", optional = true, package = "futures" }
 tokio = { version = "0.2", optional = true }
-#tokio-01 = { version = "0.1", optional = true, package = "tokio" }
 
 [dev-dependencies]
 futures = { version = "0.3.1" }
@@ -29,7 +28,6 @@ sink = ["futures-sink", "futures_03"]
 futures_03 = ["futures-core"]
 futures_01 = ["futures-01"]
 tokio-io = ["tokio"]
-#tokio-io_01 = ["tokio-01"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = ["sink"]
 sink = ["futures-sink", "futures_03"]
 futures_03 = ["futures-core"]
 futures_01 = ["futures-01"]
-tokio-io = ["tokio", "tokio/io-util"]
+tokio-io = ["tokio"]
 #tokio-io_01 = ["tokio-01"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ readme = "README.md"
 futures-core = { version = "0.3.1", optional = true }
 futures-sink = { version = "0.3.1", optional = true }
 futures-01 = { version = "0.1", optional = true, package = "futures" }
+tokio = { version = "0.2", optional = true }
+#tokio-01 = { version = "0.1", optional = true, package = "tokio" }
 
 [dev-dependencies]
 futures = { version = "0.3.1" }
@@ -26,6 +28,8 @@ default = ["sink"]
 sink = ["futures-sink", "futures_03"]
 futures_03 = ["futures-core"]
 futures_01 = ["futures-01"]
+tokio-io = ["tokio", "tokio/io-util"]
+#tokio-io_01 = ["tokio-01"]
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ with the desired number and names of variants
 
 `sink` enables support for futures 0.3 (core/std)'s `Sink`, enabled by default
 
+`tokio-io` enabled support for tokio 0.2's `AsyncRead` and `AsyncWrite`
+
 `futures_01` enables support for futures 0.1 under the futures_01 module
 
 ## Usage

--- a/src/futures_03.rs
+++ b/src/futures_03.rs
@@ -159,7 +159,7 @@ macro_rules! impl_one_of (
                 $head_variant: $crate::AsyncRead,
                 $( $tail_variants: $crate::AsyncRead ),* {
 
-            fn poll_read(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>, buf: &mut [u8]) -> ::core::task::Poll<tokio::io::Result<usize>> {
+            fn poll_read(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>, buf: &mut [u8]) -> ::core::task::Poll<::std::io::Result<usize>> {
                 unsafe {
                     match self.get_unchecked_mut() {
                         $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_read(cx, buf),
@@ -186,7 +186,7 @@ macro_rules! impl_one_of (
             where
                 $head_variant: $crate::AsyncWrite,
                 $( $tail_variants: $crate::AsyncWrite ),* {
-            fn poll_write(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>, buf: &[u8]) -> ::core::task::Poll<tokio::io::Result<usize>> {
+            fn poll_write(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>, buf: &[u8]) -> ::core::task::Poll<::std::io::Result<usize>> {
                 unsafe {
                     match self.get_unchecked_mut() {
                         $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_write(cx, buf),
@@ -197,7 +197,7 @@ macro_rules! impl_one_of (
                 }
             }
 
-            fn poll_flush(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<tokio::io::Result<()>> {
+            fn poll_flush(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<::std::io::Result<()>> {
                 unsafe {
                     match self.get_unchecked_mut() {
                         $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_flush(cx),
@@ -208,7 +208,7 @@ macro_rules! impl_one_of (
                 }
             }
 
-            fn poll_shutdown(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<tokio::io::Result<()>> {
+            fn poll_shutdown(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<::std::io::Result<()>> {
                 unsafe {
                     match self.get_unchecked_mut() {
                         $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_shutdown(cx),

--- a/src/futures_03.rs
+++ b/src/futures_03.rs
@@ -100,11 +100,11 @@ macro_rules! impl_one_of (
         }
 
         #[cfg(feature = "sink")]
-        impl<Item, $head_variant, $($tail_variants),*> futures_sink::Sink<Item> for
+        impl<Item, $head_variant, $($tail_variants),*> $crate::Sink<Item> for
             $enum_name<$head_variant, $( $tail_variants ),*>
             where
-                $head_variant: futures_sink::Sink<Item>,
-                $( $tail_variants: futures_sink::Sink<Item, Error=$head_variant::Error> ),* {
+                $head_variant: $crate::Sink<Item>,
+                $( $tail_variants: $crate::Sink<Item, Error=$head_variant::Error> ),* {
             type Error = $head_variant::Error;
 
             fn poll_ready(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) ->::core::task::Poll<Result<(), Self::Error>> {
@@ -146,6 +146,76 @@ macro_rules! impl_one_of (
                         $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_close(cx),
                         $(
                             $enum_name::$tail_variants(x) => ::core::pin::Pin::new_unchecked(x).poll_close(cx),
+                        )*
+                    }
+                }
+            }
+        }
+        
+        #[cfg(feature = "tokio")]
+        impl<$head_variant, $($tail_variants), *> $crate::AsyncRead for
+            $enum_name<$head_variant, $( $tail_variants),*>
+            where
+                $head_variant: $crate::AsyncRead,
+                $( $tail_variants: $crate::AsyncRead ),* {
+            
+            fn poll_read(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>, buf: &mut [u8]) -> ::core::task::Poll<tokio::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() {
+                        $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_read(cx, buf),
+                        $(
+                            $enum_name::$tail_variants(x) => ::core::pin::Pin::new_unchecked(x).poll_read(cx, buf),
+                        )*
+                    }
+                }
+            }
+            
+            unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [::core::mem::MaybeUninit<u8>]) -> bool {
+                unsafe {
+                    match self {
+                        $enum_name::$head_variant(x) => x.prepare_uninitialized_buffer(buf),
+                        $(
+                            $enum_name::$tail_variants(x) => x.prepare_uninitialized_buffer(buf),
+                        )*
+                    }
+                }
+            }
+        }
+        
+        #[cfg(feature = "tokio")]
+        impl<$head_variant, $($tail_variants), *> $crate::AsyncWrite for
+            $enum_name<$head_variant, $( $tail_variants),*>
+            where
+                $head_variant: $crate::AsyncWrite,
+                $( $tail_variants: $crate::AsyncWrite ),* {
+            fn poll_write(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>, buf: &[u8]) -> ::core::task::Poll<tokio::io::Result<usize>> {
+                unsafe {
+                    match self.get_unchecked_mut() {
+                        $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_write(cx, buf),
+                        $(
+                            $enum_name::$tail_variants(x) => ::core::pin::Pin::new_unchecked(x).poll_write(cx, buf),
+                        )*
+                    }
+                }
+            }
+            
+            fn poll_flush(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<tokio::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() {
+                        $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_flush(cx),
+                        $(
+                            $enum_name::$tail_variants(x) => ::core::pin::Pin::new_unchecked(x).poll_flush(cx),
+                        )*
+                    }
+                }
+            }
+            
+            fn poll_shutdown(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<tokio::io::Result<()>> {
+                unsafe {
+                    match self.get_unchecked_mut() {
+                        $enum_name::$head_variant(x) => ::core::pin::Pin::new_unchecked(x).poll_shutdown(cx),
+                        $(
+                            $enum_name::$tail_variants(x) => ::core::pin::Pin::new_unchecked(x).poll_shutdown(cx),
                         )*
                     }
                 }

--- a/src/futures_03.rs
+++ b/src/futures_03.rs
@@ -151,14 +151,14 @@ macro_rules! impl_one_of (
                 }
             }
         }
-        
+
         #[cfg(feature = "tokio")]
         impl<$head_variant, $($tail_variants), *> $crate::AsyncRead for
             $enum_name<$head_variant, $( $tail_variants),*>
             where
                 $head_variant: $crate::AsyncRead,
                 $( $tail_variants: $crate::AsyncRead ),* {
-            
+
             fn poll_read(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>, buf: &mut [u8]) -> ::core::task::Poll<tokio::io::Result<usize>> {
                 unsafe {
                     match self.get_unchecked_mut() {
@@ -169,19 +169,17 @@ macro_rules! impl_one_of (
                     }
                 }
             }
-            
+
             unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [::core::mem::MaybeUninit<u8>]) -> bool {
-                unsafe {
-                    match self {
-                        $enum_name::$head_variant(x) => x.prepare_uninitialized_buffer(buf),
-                        $(
-                            $enum_name::$tail_variants(x) => x.prepare_uninitialized_buffer(buf),
-                        )*
-                    }
+                match self {
+                    $enum_name::$head_variant(x) => x.prepare_uninitialized_buffer(buf),
+                    $(
+                        $enum_name::$tail_variants(x) => x.prepare_uninitialized_buffer(buf),
+                    )*
                 }
             }
         }
-        
+
         #[cfg(feature = "tokio")]
         impl<$head_variant, $($tail_variants), *> $crate::AsyncWrite for
             $enum_name<$head_variant, $( $tail_variants),*>
@@ -198,7 +196,7 @@ macro_rules! impl_one_of (
                     }
                 }
             }
-            
+
             fn poll_flush(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<tokio::io::Result<()>> {
                 unsafe {
                     match self.get_unchecked_mut() {
@@ -209,7 +207,7 @@ macro_rules! impl_one_of (
                     }
                 }
             }
-            
+
             fn poll_shutdown(self: ::core::pin::Pin<&mut Self>, cx: &mut ::core::task::Context<'_>) -> ::core::task::Poll<tokio::io::Result<()>> {
                 unsafe {
                     match self.get_unchecked_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,12 @@ pub use futures_03::*;
 #[cfg(feature = "futures_03")]
 pub use futures_core::{FusedFuture, FusedStream, Stream};
 
+#[cfg(feature = "sink")]
+pub use futures_sink::Sink;
+
+#[cfg(feature = "tokio")]
+pub use tokio::io::{AsyncRead, AsyncWrite};
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/test-futures-03/Cargo.toml
+++ b/test-futures-03/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-one-of-futures = { path = ".." }
+one-of-futures = { path = "..", features = ["tokio-io"] }
 futures = "0.3"

--- a/test-futures-03/src/main.rs
+++ b/test-futures-03/src/main.rs
@@ -1,4 +1,4 @@
-use one_of_futures::{impl_one_of, OneOf7};
+use one_of_futures::{impl_one_of, OneOf7, OneOf2};
 
 impl_one_of!(MyEither;
   Left,
@@ -17,7 +17,9 @@ mod tests {
     use core::task::Poll;
     use futures::executor::block_on;
     use futures::{pin_mut, poll};
-
+    use std::io::Cursor;
+    use one_of_futures::{AsyncRead, AsyncWrite};
+    
     use super::*;
 
     #[test]
@@ -36,5 +38,23 @@ mod tests {
             pin_mut!(one_of_7);
             assert_eq!(Poll::Ready(2), poll!(&mut one_of_7));
         });
+    }
+    
+    fn only_accepts_asyncread(_: impl AsyncRead) {}
+    
+    fn only_accepts_asyncwrite(_: impl AsyncWrite) {}
+    
+    #[test]
+    fn it_work_03_io() {
+        let read_cursor = Cursor::new(vec![0u8, 1, 2]);
+        let write_cursor = Cursor::new(vec![9u8, 8, 7]);
+        
+        let one_of_2 = match 1 {
+            1 => OneOf2::One(read_cursor),
+            _ => OneOf2::Two(write_cursor),
+        };
+        
+        only_accepts_asyncread(one_of_2.clone());
+        only_accepts_asyncwrite(one_of_2);
     }
 }

--- a/test-futures-03/src/main.rs
+++ b/test-futures-03/src/main.rs
@@ -1,4 +1,4 @@
-use one_of_futures::{impl_one_of, OneOf7, OneOf2};
+use one_of_futures::{impl_one_of, OneOf2, OneOf7};
 
 impl_one_of!(MyEither;
   Left,
@@ -17,9 +17,9 @@ mod tests {
     use core::task::Poll;
     use futures::executor::block_on;
     use futures::{pin_mut, poll};
-    use std::io::Cursor;
     use one_of_futures::{AsyncRead, AsyncWrite};
-    
+    use std::io::Cursor;
+
     use super::*;
 
     #[test]
@@ -39,21 +39,21 @@ mod tests {
             assert_eq!(Poll::Ready(2), poll!(&mut one_of_7));
         });
     }
-    
+
     fn only_accepts_asyncread(_: impl AsyncRead) {}
-    
+
     fn only_accepts_asyncwrite(_: impl AsyncWrite) {}
-    
+
     #[test]
     fn it_work_03_io() {
         let read_cursor = Cursor::new(vec![0u8, 1, 2]);
         let write_cursor = Cursor::new(vec![9u8, 8, 7]);
-        
+
         let one_of_2 = match 1 {
             1 => OneOf2::One(read_cursor),
             _ => OneOf2::Two(write_cursor),
         };
-        
+
         only_accepts_asyncread(one_of_2.clone());
         only_accepts_asyncwrite(one_of_2);
     }


### PR DESCRIPTION
This PR adds automatic impl for `AsyncRead` and `AsyncWrite` of tokio 0.2.

This feature is gated behind the feature `tokio-io`